### PR TITLE
Add goal platform and restart flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
 </head>
 <body>
   <canvas id="gameCanvas" width="800" height="450"></canvas>
-  <div id="messageOverlay" aria-live="polite"></div>
+  <div id="messageOverlay" aria-live="polite" role="status">
+    <span id="messageText"></span>
+    <button id="restartButton" type="button" hidden>Genstart</button>
+  </div>
   <script src="game.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -21,8 +21,33 @@ canvas {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  min-width: 200px;
+  text-align: center;
 }
 
 #messageOverlay.visible {
   opacity: 1;
+}
+
+#messageOverlay.persistent {
+  pointer-events: auto;
+}
+
+#messageOverlay button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background: #ffd166;
+  color: #333;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#messageOverlay button:focus {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add a rightmost goal platform flagged with `isGoal` and highlight it in rendering
- pause gameplay when the goal is reached and show a persistent "Du klarede niveauet!" overlay
- provide restart controls via overlay button and keyboard shortcuts to reset the level

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd3a85612c832a85b7dc4eb4c78b57