### PR TITLE
Align score and message overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,12 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="scoreDisplay" aria-live="polite">Score: <span id="scoreValue">0</span></div>
+  <div class="overlay" id="scoreOverlay" aria-live="polite" role="status">
+    <span>Score:</span>
+    <span id="scoreValue">0</span>
+  </div>
   <canvas id="gameCanvas" width="800" height="450"></canvas>
-  <div id="messageOverlay" aria-live="polite" role="status">
+  <div class="overlay" id="messageOverlay" aria-live="polite" role="status">
     <span id="messageText"></span>
     <button id="restartButton" type="button" hidden>Genstart</button>
   </div>

--- a/style.css
+++ b/style.css
@@ -4,41 +4,47 @@ body {
   background: #eef;
   font-family: sans-serif;
 }
+
 canvas {
   display: block;
   background: #aaddff;
 }
-#scoreDisplay {
+
+.overlay {
   position: absolute;
-  top: 16px;
-  left: 20px;
-  padding: 8px 14px;
-  background: rgba(0, 0, 0, 0.65);
-  color: #fff;
-  border-radius: 6px;
-  font-size: 18px;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-}
-#messageOverlay {
-  position: absolute;
-  top: 20px;
-  left: 50%;
-  transform: translateX(-50%);
   padding: 12px 20px;
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
   border-radius: 6px;
   font-size: 16px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  line-height: 1.4;
   display: flex;
-  flex-direction: column;
   align-items: center;
+  gap: 8px;
+}
+
+#scoreOverlay {
+  top: 16px;
+  left: 20px;
+}
+
+#scoreOverlay #scoreValue {
+  font-variant-numeric: tabular-nums;
+}
+
+#messageOverlay {
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column;
   gap: 12px;
   min-width: 200px;
   text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 #messageOverlay.visible {


### PR DESCRIPTION
## Summary
- restructure the score markup to share the same overlay wrapper pattern as the message overlay
- extract shared overlay styling into a reusable class applied to both overlays for consistent presentation
- keep the score value span and related selectors intact for dynamic updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd47e0ca14832a85d73460bf1bd277