### PR TITLE
Add modal trigger for platform reach events

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,18 @@
     <span id="messageText"></span>
     <button id="restartButton" type="button" hidden>Genstart</button>
   </div>
+  <div
+    class="modal"
+    id="platformModal"
+    role="dialog"
+    aria-modal="true"
+    aria-hidden="true"
+  >
+    <div class="modal-content" role="document">
+      <p id="platformModalText"></p>
+      <button id="platformModalClose" type="button">Fortsæt</button>
+    </div>
+  </div>
   <script src="game.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ canvas {
   display: flex;
   align-items: center;
   gap: 8px;
+  z-index: 10;
 }
 
 #scoreOverlay {
@@ -67,5 +68,52 @@ canvas {
 
 #messageOverlay button:focus {
   outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 50;
+}
+
+.modal.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  background: #fff;
+  color: #222;
+  padding: 24px 28px;
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+  max-width: 320px;
+  width: calc(100% - 40px);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#platformModalClose {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 4px;
+  background: #4caf50;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#platformModalClose:focus {
+  outline: 3px solid rgba(76, 175, 80, 0.35);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- add an `onReach` platform hook that pauses gameplay and opens a modal with platform-specific text
- introduce a reusable modal with close controls and keyboard handling to resume play cleanly
- style the new modal overlay alongside existing overlays for consistent presentation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd49434790832ab744512591fb7b65